### PR TITLE
fix VS crash empty line tab indent in XAML

### DIFF
--- a/CommandManager/CommandRouter.cs
+++ b/CommandManager/CommandRouter.cs
@@ -94,7 +94,14 @@ namespace Microsoft.VisualStudio.Editor.EmacsEmulation
                 }
             }
 
-            return this.Next.Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut);
+            try
+            {
+                return this.Next.Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut);
+            }
+            catch (ArgumentException)
+            {
+                return (int)OLE.Interop.Constants.OLECMDERR_E_CANCELED;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This pull request fix VS crash in XAML files when tab indenting at empty line.

When I tab indent at empty line in XAML files like below figure, Emacs Emulation throws an exception.
![image](https://user-images.githubusercontent.com/70808018/194739823-cf3c9c40-a5a9-4e54-bbd3-03007daae072.png)

This problems occurs when indenting is None or Smart.
[Text Editor] -> [XAML] -> [Tabs] -> [Indenting]
![image](https://user-images.githubusercontent.com/70808018/194739780-69c4761b-a3b6-4107-8966-6b755c3a78e6.png)

I fixed this problem by doing nothing when catching the exception.